### PR TITLE
Updated bower registry URL in .bowerrc

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -7,7 +7,8 @@ Microsoft has removed the Bower Configuration File template from Visual Studio. 
 
     ````
     {
-        "directory": "wwwroot/lib"
+        "directory": "wwwroot/lib",
+        "registry": "https://registry.bower.io"
     }
 
 3. Save the changes. (This is important - you must save the changes to the `.bowerrc` file before proceeding)


### PR DESCRIPTION
Bower is deprecating their registry hosted with heroku. http://bower.herokuapp.com/ wont be accessible any more or it might be down intermittently there by forcing users to new registry.

Source: https://stackoverflow.com/questions/51020317/einvres-request-to-https-bower-herokuapp-com-packages-failed-with-502

Here's a blog entry from Justin Clareburt (MSFT) with more information: https://blogs.msdn.microsoft.com/webdev/2018/07/05/workaround-for-bower-version-deprecation/