### PR TITLE
Update appsettings.json

### DIFF
--- a/08 - SportsStore/SportsStore/SportsStore/appsettings.json
+++ b/08 - SportsStore/SportsStore/SportsStore/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "Data": {
-    "SportStoreProducts": {
+    "SportsStoreProducts": {
       "ConnectionString": "Server=(localdb)\\MSSQLLocalDB;Database=SportsStore;Trusted_Connection=True;MultipleActiveResultSets=true"
     }
   }


### PR DESCRIPTION
The property name has a typo, which causes a null reference exception to be raised on initial migration